### PR TITLE
Add compatibility for kernels 5.19+

### DIFF
--- a/driver/usbmouse.c
+++ b/driver/usbmouse.c
@@ -24,6 +24,7 @@
 #include <linux/init.h>
 #include <linux/usb/input.h>
 #include <linux/hid.h>
+#include <linux/version.h>
 
 /* for apple IDs */
 /*                                                              //Leetmouse Mod BEGIN
@@ -180,7 +181,12 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
         return -ENODEV;
 
     pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-    maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+
+    #if LINUX_VERSION_MAJOR >= 5 && LINUX_VERSION_PATCHLEVEL > 18
+        maxp = usb_maxpacket(dev, pipe);
+    #else
+        maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+    #endif
 
     mouse = kzalloc(sizeof(struct usb_mouse), GFP_KERNEL);
     input_dev = input_allocate_device();


### PR DESCRIPTION
The function usb_maxpacket now accepts only 2 parameters instead of 3 as from kernel 5.19. Added a check for builds running on older kernels and newer ones, and use the 2 parameter or 3 parameter function accordingly.