### PR TITLE
Fixes to allow correct build

### DIFF
--- a/driver/accel.c
+++ b/driver/accel.c
@@ -87,18 +87,18 @@ INLINE void updata_params(ktime_t now)
 // Acceleration happens here
 int accelerate(int *x, int *y, int *wheel)
 {
-	float delta_x, delta_y, delta_whl, ms, speed, accel_sens, product, motivity;
-    float e = 2.71828f;
+    float delta_x, delta_y, delta_whl, ms, speed, accel_sens, product, motivity;
+    const float e = 2.71828f;
     static long buffer_x = 0;
     static long buffer_y = 0;
     static long buffer_whl = 0;
     //Static float assignment should happen at compile-time and thus should be safe here. However, avoid non-static assignment of floats outside kernel_fpu_begin()/kernel_fpu_end()
-	static float carry_x = 0.0f;
+    static float carry_x = 0.0f;
     static float carry_y = 0.0f;
     static float carry_whl = 0.0f;
-	static float last_ms = 1.0f;
-	static ktime_t last;
-	ktime_t now;
+    static float last_ms = 1.0f;
+    static ktime_t last;
+    ktime_t now;
     int status = 0;
 
     // We can only safely use the FPU in an IRQ event when this returns 1.

--- a/driver/config.sample.h
+++ b/driver/config.sample.h
@@ -16,25 +16,13 @@
 #define ACCELERATION 0.26f
 #define SENS_CAP 4.0f
 #define OFFSET 0.0f
-#define POST_SCALE_X 0.4f
-#define POST_SCALE_Y 0.4f
 #define SPEED_CAP 0.0f
 
-// Prescaler for different DPI values. 1.0f at 400 DPI. To adjust it for <your_DPI>, calculate 400/your_DPI
-
-// Generic @ 400 DPI
-#define PRE_SCALE_X 1.0f
-#define PRE_SCALE_Y 1.0f
-
-// Steelseries Rival 110 @ 7200 DPI
-//#define PRE_SCALE_X 0.0555555f
-//define PRE_SCALE_Y 0.0555555f
-
-// Steelseries Rival 600/650 @ 12000 DPI
-//#define PRE_SCALE_X 0.0333333f
-//#define PRE_SCALE_Y 0.0333333f
-
+// 1 for Linear, 2 for Classic and 3 for Motivity
 #define ACCELERATION_MODE 1
 
 // For exponential curves.
 #define EXPONENT 2.0f
+
+// For sigmoidal curves.
+#define MIDPOINT 1.0f

--- a/driver/usbmouse.c
+++ b/driver/usbmouse.c
@@ -24,6 +24,7 @@
 #include <linux/init.h>
 #include <linux/usb/input.h>
 #include <linux/hid.h>
+#include <linux/version.h>
 
 /* for apple IDs */
 /*                                                              //Leetmouse Mod BEGIN
@@ -180,7 +181,11 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
         return -ENODEV;
 
     pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-    maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
+        maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+    #else
+        maxp = usb_maxpacket(dev, pipe);
+    #endif
 
     mouse = kzalloc(sizeof(struct usb_mouse), GFP_KERNEL);
     input_dev = input_allocate_device();


### PR DESCRIPTION
I followed the installation instructions and, differently from [systemofapwne's implementation](https://github.com/systemofapwne/leetmouse), I could not Install the driver and activate the dkms module.

I found out that the sample configuration (config.sample.h) file was not matching the processing code (accel.c). After setting it up, I could continue with the installation.