### PR TITLE
Update usbmouse.c

### DIFF
--- a/driver/usbmouse.c
+++ b/driver/usbmouse.c
@@ -180,7 +180,7 @@ static int usb_mouse_probe(struct usb_interface *intf, const struct usb_device_i
         return -ENODEV;
 
     pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-    maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+    maxp = usb_maxpacket(dev, pipe);
 
     mouse = kzalloc(sizeof(struct usb_mouse), GFP_KERNEL);
     input_dev = input_allocate_device();


### PR DESCRIPTION
usb_maxpacket now has only 2 arguments, the thirs pipe direction was redundant and was removed from the linux kernel